### PR TITLE
Add container-tool config option

### DIFF
--- a/AmazonQ.md
+++ b/AmazonQ.md
@@ -231,4 +231,4 @@ The output MCP JSON file would look like this.
 
 # Guidelines
 
-Before making any code changes, first checkout a new git branch.  After updating code, run `make build` to ensure that the code compiles. Then, after testing, git commit your changes with a concise short message on one line along with a longer summary message.
+Before making any code changes, first checkout a new git branch.  After updating code, run `make build` to ensure that the code compiles. Run `go fmt` to ensure your code is correctly formatted. Then, after testing your changes, git commit your changes with a concise short message on one line along with a longer summary message.

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ MCP CLI supports these predefined tool shortcuts for popular AI tools:
 - `claude-desktop` - Claude Desktop (`$HOME/Library/Application Support/Claude/claude_desktop_config.json`)
 - `cursor` - Cursor IDE (`$HOME/.cursor/mcp.json`)
 
-### Setting Default Tool
+### Setting Default AI Tool
 
-Configure a default tool to avoid specifying `-t` each time:
+Configure a default AI tool to avoid specifying `-t` each time:
 
 ```sh
 # Set Amazon Q CLI as your default tool
@@ -105,6 +105,15 @@ mcp set programming
 
 # or to switch back to defaults
 mcp set
+```
+
+### Setting Container Tool
+
+If you're using containers to run your MCP servers (by setting the `image` property), then MCP CLI will output `docker` run commands by default. If you're using a different container tool such as `finch` or `podman`, etc., then you can use the `set container-tool` command.
+
+```sh
+# Set a custom container tool (default is docker)
+mcp config set container-tool finch
 ```
 
 ### Profiles

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -11,7 +11,8 @@ import (
 
 // CLIConfig represents the structure of the MCP CLI config file
 type CLIConfig struct {
-	Tool string `json:"tool,omitempty"`
+	Tool          string `json:"tool,omitempty"`
+	ContainerTool string `json:"container-tool,omitempty"`
 }
 
 var configCmd = &cobra.Command{
@@ -29,7 +30,7 @@ var configSetCmd = &cobra.Command{
 		key := args[0]
 		value := args[1]
 
-		if key != "tool" {
+		if key != "tool" && key != "container-tool" {
 			fmt.Fprintf(os.Stderr, "Error: unsupported configuration key: %s\n", key)
 			os.Exit(1)
 		}
@@ -71,6 +72,8 @@ var configSetCmd = &cobra.Command{
 		switch key {
 		case "tool":
 			config.Tool = value
+		case "container-tool":
+			config.ContainerTool = value
 		}
 
 		// Write the updated config


### PR DESCRIPTION
Adds ability to configure alternative container tools like podman or finch instead of the default docker. Updates both set and ls commands to respect this configuration.