### PR TITLE
Add local mcp-compose.yml file resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ MCP CLI simplifies managing MCP server configurations through a YAML-based appro
 
 ### Getting Started
 
-1. Create an [mcp-compose.yml](./mcp-compose.yml) file in `$HOME/.config/mcp/mcp-compose.yml` with your MCP server configurations.  See example below, or copy the included example file.
+1. Create an [mcp-compose.yml](./mcp-compose.yml) file with your MCP server configurations. You can place this file in either:
+   - Your current working directory (for project-specific configurations)
+   - `$HOME/.config/mcp/mcp-compose.yml` (for global configurations)
 
 ```sh
+# For global configuration
 mkdir -p ~/.config/mcp
 cp ./mcp-compose.yml $HOME/.config/mcp/
 ```
@@ -33,6 +36,23 @@ cp ./mcp-compose.yml $HOME/.config/mcp/
 mcp set -t q-cli # or -t cursor, -t claude-desktop
 ```
 
+### Configuration File Resolution
+
+MCP CLI automatically looks for configuration files in the following order:
+
+1. **Local directory**: `./mcp-compose.yml` in your current working directory
+2. **Global directory**: `$HOME/.config/mcp/mcp-compose.yml` in your home config directory
+3. **Custom path**: Use the `-f` flag to specify a custom location
+
+This allows you to have project-specific MCP server configurations that override your global settings when working in specific directories.
+
+```sh
+# Uses local mcp-compose.yml if it exists, otherwise falls back to global
+mcp ls
+
+# Explicitly use a custom configuration file
+mcp ls -f ./custom-mcp-compose.yml
+```
 
 ### Listing MCP Servers
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,13 +26,24 @@ func Execute() error {
 }
 
 func init() {
+	defaultComposeFile := getDefaultComposeFile()
+	rootCmd.PersistentFlags().StringVarP(&composeFile, "file", "f", defaultComposeFile, "Path to the mcp-compose.yml file")
+}
+
+// getDefaultComposeFile returns the default compose file path, checking local directory first
+func getDefaultComposeFile() string {
+	// First check for local mcp-compose.yml in current directory
+	localComposeFile := "mcp-compose.yml"
+	if _, err := os.Stat(localComposeFile); err == nil {
+		return localComposeFile
+	}
+
+	// Fall back to the global config directory
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error getting user home directory: %v\n", err)
 		os.Exit(1)
 	}
 
-	defaultComposeFile := filepath.Join(homeDir, ".config", "mcp", "mcp-compose.yml")
-
-	rootCmd.PersistentFlags().StringVarP(&composeFile, "file", "f", defaultComposeFile, "Path to the mcp-compose.yml file")
+	return filepath.Join(homeDir, ".config", "mcp", "mcp-compose.yml")
 }

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -118,7 +118,7 @@ func getOutputPath(envVars map[string]string) (string, error) {
 	// Check if there's a default tool configured in the config file
 	configDir := getConfigDir()
 	configPath := filepath.Join(configDir, "config.json")
-	
+
 	if _, err := os.Stat(configPath); err == nil {
 		data, err := os.ReadFile(configPath)
 		if err == nil {
@@ -156,7 +156,7 @@ func convertToMCPConfig(servers map[string]Service, envVars map[string]string) M
 	containerTool := "docker"
 	configDir := getConfigDir()
 	configPath := filepath.Join(configDir, "config.json")
-	
+
 	if _, err := os.Stat(configPath); err == nil {
 		data, err := os.ReadFile(configPath)
 		if err == nil {

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -75,13 +75,13 @@ func loadEnvVars(composePath string) (map[string]string, error) {
 		if len(parts) == 2 {
 			key := strings.TrimSpace(parts[0])
 			value := strings.TrimSpace(parts[1])
-			
+
 			// Remove quotes if present
 			if (strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"")) ||
 				(strings.HasPrefix(value, "'") && strings.HasSuffix(value, "'")) {
 				value = value[1 : len(value)-1]
 			}
-			
+
 			// Only set if not already in environment
 			if _, exists := envVars[key]; !exists {
 				envVars[key] = value
@@ -126,7 +126,7 @@ func filterServers(config *ComposeConfig, profile string, all bool) map[string]S
 		// Check if this is a default server (no profile or has "default" in profile)
 		isDefault := false
 		profileStr, hasProfile := service.Labels["mcp.profile"]
-		
+
 		if !hasProfile {
 			// No profile specified, consider it default
 			isDefault = true


### PR DESCRIPTION
- MCP CLI now looks for mcp-compose.yml in current directory first
- Falls back to global ~/.config/mcp/mcp-compose.yml if local file not found
- Updated README.md to document configuration file resolution order
- Allows project-specific MCP server configurations