### PR TITLE
Add kiro support

### DIFF
--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -1,0 +1,23 @@
+# MCP CLI Product Overview
+
+MCP CLI is a command-line tool for managing Model Context Protocol (MCP) server configurations. It simplifies the pain points of working with MCP by providing a YAML-based configuration approach inspired by Docker Compose.
+
+## Core Problems Solved
+
+- Eliminates manual JSON file editing for MCP configurations
+- Manages similar config files across different AI tools (Amazon Q CLI, Claude Desktop, Cursor)
+- Handles secret environment variables securely
+- Enables experimentation with new MCP servers
+- Supports switching between different configurations based on context (programming, writing, research)
+
+## Key Features
+
+- **Profile-based organization**: Group MCP servers by use case using labels
+- **Multi-tool support**: Deploy configurations to various AI tools via shortcuts
+- **Environment variable expansion**: Secure handling of secrets and dynamic values
+- **Container support**: Works with both command-based and Docker image-based MCP servers
+- **Default configurations**: Sensible defaults with override capabilities
+
+## Target Users
+
+Developers and AI tool users who work with multiple MCP servers and need efficient configuration management across different AI tools and contexts.

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -1,0 +1,59 @@
+# Project Structure & Organization
+
+## Directory Layout
+
+```
+mcp/
+├── main.go                 # Application entry point with signal handling
+├── cmd/                    # CLI command implementations
+│   ├── root.go            # Root command and global flags
+│   ├── types.go           # Shared data structures and utilities
+│   ├── list.go            # List/ls command implementation
+│   ├── set.go             # Set command implementation
+│   ├── clear.go           # Clear command implementation
+│   └── config.go          # Config command implementation
+├── go.mod                 # Go module definition
+├── go.sum                 # Go module checksums
+├── Makefile               # Build automation
+├── mcp-compose.yml        # Example MCP server configuration
+├── .env                   # Environment variables (gitignored)
+└── app                    # Built binary output
+```
+
+## Command Structure
+
+All CLI commands follow the Cobra pattern:
+
+- Each command is a separate file in `cmd/`
+- Commands are registered in their `init()` functions
+- Shared functionality lives in `cmd/types.go`
+
+## Configuration Files
+
+### User Configuration Locations
+
+- **Compose file**: `$HOME/.config/mcp/mcp-compose.yml` (default)
+- **CLI config**: `$HOME/.config/mcp/config.json`
+- **Environment**: `.env` file in same directory as compose file
+
+### Tool-specific Output Locations
+
+- **Amazon Q CLI**: `$HOME/.aws/amazonq/mcp.json`
+- **Claude Desktop**: `$HOME/Library/Application Support/Claude/claude_desktop_config.json`
+- **Cursor**: `$HOME/.cursor/mcp.json`
+
+## Data Flow
+
+1. Load `mcp-compose.yml` (Docker Compose format)
+2. Load environment variables from system + `.env` file
+3. Filter services by profile using `mcp.profile` labels
+4. Transform to MCP JSON format with environment expansion
+5. Write to tool-specific configuration location
+
+## Key Conventions
+
+- **Profile organization**: Use `mcp.profile` labels for grouping servers
+- **Environment expansion**: Support `${VAR}` and `$VAR` syntax
+- **Default behavior**: Services without profiles are considered "default"
+- **Container support**: Services can use `command` or `image` fields
+- **Error handling**: Exit with status 1 on errors, write to stderr

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -1,0 +1,56 @@
+# Technology Stack & Build System
+
+## Tech Stack
+
+- **Language**: Go 1.24.2
+- **CLI Framework**: Cobra (github.com/spf13/cobra v1.9.1)
+- **YAML Processing**: gopkg.in/yaml.v3 v3.0.1
+- **Build System**: Make + Go toolchain
+
+## Architecture Patterns
+
+- **Command Pattern**: Each CLI command is implemented as a separate Cobra command in the `cmd/` package
+- **Configuration as Code**: Uses Docker Compose YAML format for MCP server definitions
+- **Environment Variable Expansion**: Supports `${VAR}` and `$VAR` syntax with .env file loading
+- **Profile-based Filtering**: Uses Docker Compose labels for organizing servers by use case
+
+## Key Dependencies
+
+```go
+require (
+    github.com/spf13/cobra v1.9.1    // CLI framework
+    gopkg.in/yaml.v3 v3.0.1          // YAML parsing
+)
+```
+
+## Common Commands
+
+### Development
+
+```bash
+make build      # Build binary to ./app
+make test       # Run unit tests with race detection
+make vet        # Vet code for issues
+make start      # Build and run locally
+```
+
+### Auto-development
+
+```bash
+make autobuild  # Auto-rebuild on file changes (requires reflex)
+```
+
+### Container Operations
+
+```bash
+make dockerbuild  # Build Docker image
+make deploy       # Deploy to cloud dev environment
+```
+
+## File Structure Conventions
+
+- `main.go`: Entry point with signal handling
+- `cmd/`: All CLI commands and shared types
+- `cmd/root.go`: Root command and global flags
+- `cmd/types.go`: Shared data structures and utility functions
+- Binary output: `./app`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MCP CLI is a tool for managing MCP server configuration files.
 
 ## Why?
 
-Model Context Protocol (MCP) is a new technology and still evolving.  As I've been using it, I have encountered several pain points:
+Model Context Protocol (MCP) is a new technology and still evolving. As I've been using it, I have encountered several pain points:
 
 - Manually editing JSON files
 - Managing similar config files for different AI tools
@@ -12,7 +12,7 @@ Model Context Protocol (MCP) is a new technology and still evolving.  As I've be
 - Experimenting with new MCP servers
 - Switching between different configurations based on what I'm doing (e.g., programming, writing, researching)
 
-I decided to write up some specs for a tool (written in Go) that could help with these pain points and try to "vibe code" it.  This is the result. Please don't judge the code quality. I didn't write or edit a single line :)
+I decided to write up some specs for a tool (written in Go) that could help with these pain points and try to "vibe code" it. This is the result. Please don't judge the code quality. I didn't write or edit a single line :)
 
 ## Usage
 
@@ -20,7 +20,7 @@ MCP CLI simplifies managing MCP server configurations through a YAML-based appro
 
 ### Getting Started
 
-1. Create an [mcp-compose.yml](./mcp-compose.yml) file in `$HOME/.config/mcp/mcp-compose.yml` with your MCP server configurations.  See example below, or copy the included example file.
+1. Create an [mcp-compose.yml](./mcp-compose.yml) file in `$HOME/.config/mcp/mcp-compose.yml` with your MCP server configurations. See example below, or copy the included example file.
 
 ```sh
 mkdir -p ~/.config/mcp
@@ -32,7 +32,6 @@ cp ./mcp-compose.yml $HOME/.config/mcp/
 ```sh
 mcp set -t q-cli # or -t cursor, -t claude-desktop
 ```
-
 
 ### Listing MCP Servers
 
@@ -68,6 +67,9 @@ mcp set programming -t cursor
 # Set a specific server for Claude Desktop
 mcp set -t claude-desktop -s github
 
+# Set programming profile servers for Kiro IDE
+mcp set programming -t kiro
+
 # Use a custom output location
 mcp set -c /path/to/output/mcp.json
 ```
@@ -91,6 +93,7 @@ MCP CLI supports these predefined tool shortcuts for popular AI tools:
 - `q-cli` - Amazon Q CLI (`$HOME/.aws/amazonq/mcp.json`)
 - `claude-desktop` - Claude Desktop (`$HOME/Library/Application Support/Claude/claude_desktop_config.json`)
 - `cursor` - Cursor IDE (`$HOME/.cursor/mcp.json`)
+- `kiro` - Kiro IDE (`$HOME/.kiro/settings/mcp.json`)
 
 ### Setting Default AI Tool
 
@@ -122,7 +125,6 @@ Organize your MCP servers with profiles using the `labels` field in your `mcp-co
 
 ```yaml
 services:
-
   brave:
     image: mcp/brave-search
     environment:
@@ -144,7 +146,6 @@ mcp set programming -t claude-desktop
 
 Services without the label are considered defaults.
 
-
 ## How?
 
 It turns out that the Docker Compose (`docker-compose.yml`) specification already has good support for MCP stdio configuration where services map to MCP servers with `command`s, `image`s, `environment`s/`env_files`s, and `label`s for profiles. Another added benefit of this is you can run `docker compose pull -f mcp-compose.yml` and it will pre-fetch all the container images.
@@ -154,7 +155,6 @@ Example:
 ```yaml
 # MCP Servers
 services:
-
   time:
     command: uvx mcp-server-time
 
@@ -179,7 +179,6 @@ services:
     command: npx -y @modelcontextprotocol/server-postgres postgresql://localhost/mydb
     labels:
       mcp.profile: database
-
 
   # OR container based MCP servers
 

--- a/cmd/clear.go
+++ b/cmd/clear.go
@@ -44,5 +44,5 @@ var clearCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(clearCmd)
 	clearCmd.Flags().StringVarP(&configFile, "config", "c", "", "Path to write the MCP JSON configuration file")
-	clearCmd.Flags().StringVarP(&toolShortcut, "tool", "t", "", "Tool shortcut (q-cli, claude-desktop, cursor)")
+	clearCmd.Flags().StringVarP(&toolShortcut, "tool", "t", "", "Tool shortcut (q-cli, claude-desktop, cursor, kiro)")
 }

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -21,6 +21,7 @@ var toolShortcuts = map[string]string{
 	"q-cli":          filepath.Join("${HOME}", ".aws", "amazonq", "mcp.json"),
 	"claude-desktop": filepath.Join("${HOME}", "Library", "Application Support", "Claude", "claude_desktop_config.json"),
 	"cursor":         filepath.Join("${HOME}", ".cursor", "mcp.json"),
+	"kiro":           filepath.Join("${HOME}", ".kiro", "settings", "mcp.json"),
 }
 
 // setCmd represents the set command
@@ -84,7 +85,7 @@ If no profile is specified, it uses default servers.`,
 func init() {
 	rootCmd.AddCommand(setCmd)
 	setCmd.Flags().StringVarP(&configFile, "config", "c", "", "Path to write the MCP JSON configuration file")
-	setCmd.Flags().StringVarP(&toolShortcut, "tool", "t", "", "Tool shortcut (q-cli, claude-desktop, cursor)")
+	setCmd.Flags().StringVarP(&toolShortcut, "tool", "t", "", "Tool shortcut (q-cli, claude-desktop, cursor, kiro)")
 	setCmd.Flags().StringVarP(&singleServer, "server", "s", "", "Specify a single server to include")
 }
 
@@ -118,7 +119,7 @@ func getOutputPath(envVars map[string]string) (string, error) {
 	// Check if there's a default tool configured in the config file
 	configDir := getConfigDir()
 	configPath := filepath.Join(configDir, "config.json")
-	
+
 	if _, err := os.Stat(configPath); err == nil {
 		data, err := os.ReadFile(configPath)
 		if err == nil {
@@ -156,7 +157,7 @@ func convertToMCPConfig(servers map[string]Service, envVars map[string]string) M
 	containerTool := "docker"
 	configDir := getConfigDir()
 	configPath := filepath.Join(configDir, "config.json")
-	
+
 	if _, err := os.Stat(configPath); err == nil {
 		data, err := os.ReadFile(configPath)
 		if err == nil {


### PR DESCRIPTION
- Add kiro tool shortcut that outputs to `~/.kiro/settings/mcp.json`
- Update both set and clear commands to support kiro option
- Update README documentation with Kiro support and usage examples
- Tested functionality works correctly for both set and clear operations